### PR TITLE
use simpler and standard setup.cfg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,31 @@
+PYFILES = ms_client/ examples/
+
+all:
+
+format:
+	black ${PYFILES}
+
+lint:
+	flake8 ${PYFILES}
+
+develop:
+	pip install -e .[dev]
+
+build: clean
+	python setup.py sdist bdist_wheel
+
+install: build
+	pip install -I dist/mediaserver_api_client-*.whl
+
+publish_dry: build
+	twine check dist/*.{whl,tar.gz}
+	twine upload --repository-url https://test.pypi.org/legacy/ dist/*.{whl,tar.gz}
+
+publish: build
+	twine check dist/*.{whl,tar.gz}
+	twine upload dist/*.{whl,tar.gz}
+
+clean:
+	rm -rf .eggs/ build/ dist/ *.egg-info/
+	find . -type f -name *.pyc -delete
+	find . -type d -name __pycache__ -delete

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,48 @@
+[metadata]
+name = mediaserver-api-client
+version = attr: ms_client.__version__
+description = A python3 reference implementation of an UbiCast MediaServer API client
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://www.ubicast.eu/en/solutions/delivery/
+download_url = https://github.com/UbiCastTeam/mediaserver-client
+author = UbiCast
+author_email = dev@ubicast.eu
+keywords =
+    api
+    client
+    mediaserver
+    ubicast
+license = LGPLv3
+license_file = LICENSE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Topic :: Multimedia :: Video
+    Topic :: Software Development :: Libraries :: Python Modules
+
+[options]
+include_package_data = True
+install_requires =
+    requests ~= 2.21
+packages =
+    ms_client
+setup_requires=
+    setuptools
+    wheel
+
+[options.package_data]
+ms_client =
+    conf.json
+
+[options.extras_require]
+dev =
+    black
+    flake8
+    twine
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,28 +1,6 @@
-#!/usr/bin/python3
-# -*- coding: utf-8 -*-
-import os
-from setuptools import setup
+#!/usr/bin/env python3
+
+import setuptools
 
 
-# get version without importing module
-version = None
-with open(os.path.join(os.path.dirname(__file__), 'ms_client', '__init__.py'), 'r') as fo:
-    for line in fo:
-        if line.startswith('__version__'):
-            version = line[len('__version__'):].strip(' =\'"\n\t')
-            break
-
-
-setup(
-    name='ms_client',
-    version=version,
-    description='A Python3 client to interact with an UbiCast MediaServer site.',
-    author='UbiCast',
-    url='https://github.com/UbiCastTeam/mediaserver-client',
-    license='LGPL v3',
-    packages=['ms_client'],
-    package_data={'ms_client': ['conf.json']},
-    scripts=[],
-    setup_requires=['setuptools'],
-    install_requires=['requests'],
-)
+setuptools.setup()


### PR DESCRIPTION
Ça s'installe avec setup.py tout pareil (100% compatible, c'est toujours du setuptools en fait, cf. https://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files). C'est plus propre, pas de hack bizarre pour récupérer la version, etc.

Et j'ai ajouté un makefile pour build et upload le paquet sur PyPI.