### PR TITLE
ensure download_metadata_zip really produces a zip file and fix download_metadata_zip

### DIFF
--- a/ms_client/lib/content.py
+++ b/ms_client/lib/content.py
@@ -6,6 +6,7 @@ This module is not intended to be used directly, only the client class should be
 '''
 import logging
 import os
+import zipfile
 
 logger = logging.getLogger('ms_client.lib.content')
 
@@ -46,6 +47,11 @@ def download_metadata_zip(client, media_oid, path, include_annotations=None, inc
     with open(path, 'wb') as fo:
         for chunk in req.iter_content(10000000):  # 10 MB chunks
             fo.write(chunk)
+
+    # check that the file is really a zip file
+    zip_file = zipfile.ZipFile(path, 'r')
+    if zip_file.testzip():
+        raise Exception('Invalid zip file')
     return path
 
 

--- a/ms_client/lib/content.py
+++ b/ms_client/lib/content.py
@@ -16,7 +16,6 @@ def add_media(client, title=None, file_path=None, progress_callback=None, progre
         raise ValueError('You should give a title or a file to create a media.')
     if file_path is not None and os.path.getsize(file_path) == 0:
         raise Exception('File is empty: %s' % file_path)
-    client.get_server_version()  # ping server to test the connection and log version for debug
     metadata = kwargs
     metadata['origin'] = client.conf['CLIENT_ID']
     if title:


### PR DESCRIPTION
Sometimes the download_metadata_zip method may not produce a zip file but an html page; this should never be silent, as it produces invalid backups.