### PR TITLE
Always follow redirections

### DIFF
--- a/ms_client/client.py
+++ b/ms_client/client.py
@@ -141,6 +141,7 @@ class MediaServerClient():
                 timeout=timeout or self.conf['TIMEOUT'],
                 proxies=self.conf['PROXIES'],
                 verify=self.conf['VERIFY_SSL'],
+                allow_redirects=True,
             )
             status_code = req.status_code
         except Exception as err:


### PR DESCRIPTION
When trying to HEAD on an api which redirects (typically, download_metadata_zip method), currently the client does not follow and the client crashes