### PR TITLE
Skip media from Recycle Bin from throwing an error and halting the script

### DIFF
--- a/examples/delete_video_qualities.py
+++ b/examples/delete_video_qualities.py
@@ -51,8 +51,13 @@ def remove_resources(msc, video_oid, video_title, qualities_to_delete, formats_t
 def _remove_resources(msc, video_oid, video_title, qualities_to_delete, formats_to_delete, enable_delete=False):
     logger.info(f'-- Media {video_oid} "{video_title}"')
 
-    # Update resources from video media
-    resources = msc.api('medias/resources-check/', method='post', data=dict(oid=video_oid))
+    try:
+        # Update resources from video media
+        resources = msc.api('medias/resources-check/', method='post', data=dict(oid=video_oid))
+    except Exception as e:
+        # Log error but do not halt and proceed to the next media. This can happen when the media is in the recycle bin.
+        logger.error(f'Error {e}: failed to update resources from media {video_oid}.')
+        return
 
     # Get resources from video media
     resources = msc.api('medias/resources-list/', params=dict(oid=video_oid))['resources']


### PR DESCRIPTION
@sdiemer 

Media located in the recycle bin (for instance when running on all channels from root channel) throw a HTTP 403 error on `POST /api/v2/medias/resources-check/`, therefore halting script execution.

I was unable to find out how to exclude the Recycle Bin channel so this is my solution.